### PR TITLE
Fix/credits animations

### DIFF
--- a/credits.js
+++ b/credits.js
@@ -1,30 +1,26 @@
 // credits overlay logic
 
-function closeCredits() {
-    elements.overlay.classList.remove("is-active");
-    elements.closeOverlayBtn.classList.remove("is-active");
-    document.removeEventListener("keydown", handleKeyDown);
-}
-
-function openCredits() {
-    elements.overlay.classList.add("is-active");
-    elements.closeOverlayBtn.classList.add("is-active");
-    document.addEventListener("keydown", handleKeyDown);
+function toggleCredits() {
+  const isActive = elements.overlay.classList.contains('is-active')
+  elements.overlay.classList.toggle('is-active')
+  if (isActive) {
+    document.removeEventListener('keydown', handleKeyDown)
+  } else {
+    document.addEventListener('keydown', handleKeyDown)
+  }
 }
 
 function handleKeyDown(event) {
-    if (event.key === "Escape") {
-        closeCredits();
-    }
+  if (event.key === 'Escape') {
+    toggleCredits()
+  }
 }
 
 const elements = {
-  overlay: document.querySelector(".CreditsOverlay"),
-  overlayBackdrop: document.querySelector(".CreditsOverlay-backdrop"),
-  closeOverlayBtn: document.querySelector(".CreditsOverlay-button"),
-  openOverlayBtn: document.querySelector(".Credits")
+  overlay: document.querySelector('.CreditsOverlay'),
+  overlayBackdrop: document.querySelector('.CreditsOverlay-backdrop'),
+  openOverlayBtn: document.querySelector('.Credits')
 }
 
-elements.openOverlayBtn.addEventListener("click", openCredits.bind(this),false);
-elements.closeOverlayBtn.addEventListener("click",closeCredits.bind(this),false);
-elements.overlayBackdrop.addEventListener("click",closeCredits.bind(this),false);
+elements.openOverlayBtn.addEventListener('click', toggleCredits)
+elements.overlayBackdrop.addEventListener('click', toggleCredits)

--- a/index.css
+++ b/index.css
@@ -127,6 +127,8 @@ p {
   grid-row: 1/2;
   margin-bottom: 6rem;
   text-align: right;
+	position: relative;
+	z-index: 5;
 }
 
 video-custom.Percussion {
@@ -344,64 +346,42 @@ video-custom.is-active .ActiveDot {
 
 /********* Credits overlay ******/
 
+.CreditsOverlay {}
+
 .CreditsOverlay-backdrop {
   position: fixed;
-  width:100vw;
-  height: 100vh;
-  top:0;
+  top: 0;
+	right: 0;	
 	z-index: 3;
-  background: hsla(0, 0%, 100%, 0.8);
-  /*animation: hideBackdrop 0.3s ease-in-out;*/
-  left: 150rem;
-  transition: left 0.3s ease-in-out;
-}
-
-.CreditsOverlay.is-active .CreditsOverlay-backdrop {
-  left:0;
+  width: 100%;
+	height: 100%;
+	transform: translateX(100%);
+  transition: transform 200ms ease-in-out;
+  background: hsla(0, 0%, 90%, 0.5);
 }
 
 .CreditsOverlay-content {
   position: fixed;
   top: 0;
-  right:-36rem;
-  transition: right 0.3s ease-in-out;
+	right: 0;
   z-index: 4;
-  background-color: white;
-	color: black;
-  overflow: auto;
-  padding: 4rem 2rem 0;
 	width: 36em;
   max-width: 70%;
   height:100%;
   overflow: auto;
+  padding: 4rem 2rem 0;
+  background-color: white;
+	color: black;
+	transform: translateX(100%);
+  transition: transform 150ms 50ms ease-in-out;
+}
+
+.CreditsOverlay.is-active .CreditsOverlay-backdrop {
+	transform: translateX(0);
 }
 
 .CreditsOverlay.is-active .CreditsOverlay-content {
-  right:0;
-}
-
-.CreditsOverlay-button {
-  display: none;
-}
-
-.CreditsOverlay.is-active .CreditsOverlay-button {
-  display: block;
-}
-
-/* functions to show/hid backdrop and credits' content */
-
-
-.CreditsOverlay-button {
-  position: fixed;
-  right: 1rem;
-  top: 1.3rem; 
-  z-index: 4;
-}
-
-@media (max-width: 830px) {
-	.CreditsOverlay-button {
-		top: 2.6rem;
-	}
+	transform: translateX(0);
 }
 
 /********* share dialog ******/

--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@
 
 				<p>© 2019 Brandt Brauer Frick, Because Music</p>
 			</div>
-			<button class="CreditsOverlay-button Button">Close</button>
 		</div>
 		<div class="GridOrchestra is-inactive">
 			<div class="GridOrchestra-box Presentation">


### PR DESCRIPTION
- Remove creditsoverlay close button. Instead reuse "Credits" button
- Change javascript logic of credits to "toggle" instead of open/close
- Use transform animation instead of relying on fixed `left/right` values

I wanted to reuse the Credits button so we don't have to worry about positioning the "Close" button exactly on top, don't have to deal with flickering animation etc. To do this I also changed the js logic to have a toggle method instead.

One gigantic screens, values like `right: 150rem` won't be enough. It's both faster to animate and safer to use `transform: translateX(100%)`, because the percentage value here is relative to the width of the element itself (and not the viewport).