### PR TITLE
Load videos one by one

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,29 @@
 		<link rel="stylesheet" href="https://use.typekit.net/wad5lzh.css">
 		<meta name="description" content="Masse is taken from Brandt Brauer Frick's Echo album out now!" />
 		<link rel="stylesheet" href="index.css" />
+
 		<!-- polyfill for custom elements/web components -->
 		<script>this.customElements||document.write('<script src="//unpkg.com/document-register-element"><\x2fscript>');</script>
+
 		<!-- Open Graph / Facebook -->
 		<meta property="og:url" content="https://masse.video" />
 		<meta property="og:image" content="https://masse.video/assets/masse-social.jpg"/>
+
 		<!-- Twitter -->
 		<meta property="twitter:card" content="summary_large_image" />
+
+		<!-- Preload videos -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730307.sd.mp4?s=5b4fbe022d1c93fb90fdf8202bac45bda3d5fd69&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730158.sd.mp4?s=516c5a524087d3d5a2475560c56b5c38be334770&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730229.sd.mp4?s=a2aa00b065b41e0bbdb78ec92060ed66a99de4e1&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730400.sd.mp4?s=7932ae4eb3960e392bb67d7cb5a14f5df227afc3&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730122.sd.mp4?s=9bfb5d749bedf21f316d6bd2592148152df5ebb0&profile_id=164"> -->
+		<link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730189.sd.mp4?s=b6930fdc98d29d870b1ad08b18464789373ead47&profile_id=164">
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730445.sd.mp4?s=41191bb9dbeb0eec48d8f4b041558e30272dcec4&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730076.sd.mp4?s=dda2d7780f1c4f3e2ea600b11ec899bbbae62a3c&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730356.sd.mp4?s=06ef8df945f9c67adec4d3bf11900b18a0d003b3&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730267.sd.mp4?s=2c65368f4c09af7f15c06390efbe066e52099be5&profile_id=164"> -->
+		<!-- <link rel="preload" as="fetch" href="https://player.vimeo.com/external/333730497.sd.mp4?s=3bd74a37da81cfa7d9b818945d7f4596e4bf613d&profile_id=164"> -->
 	</head>
 	<body>
 

--- a/main.js
+++ b/main.js
@@ -38,27 +38,35 @@ class View {
 		elements.videos.forEach(video => {
 			console.log(video.src)
 			const src = video.getAttribute('data-src')
-			fetch(src)
-				.then(ok => {
-					console.log({ok})
-					fetch(ok.url)
+			// fetch(src)
+			// 	.then(ok => {
+			// 		console.log({ok})
+			// 		fetch(ok.url)
 					video.addEventListener('click', this.handleVideoClick.bind(this))
 					video.addEventListener('canplay', this.canPlayHandler)
 					video.addEventListener('loadedmetadata', () => {
 						this.metadata += 1
 
 						if (video.buffered.length === 0) {
-							console.log(this.metadata, 'not ready to play')
+							console.log(this.metadata, 'not ready to play, forcing buffer?')
+							// console.log(this.src)
+							// video.muted = true
+							// video.play().then(() => {
+							// setTimeout(() => {
+							// 	video.pause()
+							// 	console.log('stop')
+							// }, 500)
+							// })
 							return
 						}
 
 						var bufferedSeconds = video.buffered.end(0) - video.buffered.start(0)
 						console.log(this.metadata, bufferedSeconds + ' seconds of video are ready to play')
 					})
-				})
-				.catch(err => {
-					console.log({err})
-				})
+				// })
+				// .catch(err => {
+				// 	console.log({err})
+				// })
 		})
 
 		elements.videos[0].parentElement.loadVideo()

--- a/video_custom.js
+++ b/video_custom.js
@@ -17,12 +17,13 @@ export class VideoCustom extends HTMLElement {
 		// <iframe src=${vimeoSrc} width="640" height="360" frameborder="0" allow="autoplay"></iframe>
 		this.html`
 			<span class="ActiveDot"></span>
-			<video title=${title} data-src=${src}></video>
+			<video muted title=${title} src=${src}></video>
 		`
 	}
 
 	loadVideo() {
 		const video = this.querySelector('video')
-		video.src = video.getAttribute('data-src')
+		const src = video.getAttribute('data-src')
+		if (src) video.src = src
 	}
 }

--- a/video_custom.js
+++ b/video_custom.js
@@ -11,9 +11,18 @@ export class VideoCustom extends HTMLElement {
 	}
 	render() {
 		const src = this.getAttribute('src')
+		const title = this.getAttribute('data-title')
+		// const id = src.split('external/')[1].split('.sd')[0]
+		// const vimeoSrc = `https://player.vimeo.com/video/${id}`
+		// <iframe src=${vimeoSrc} width="640" height="360" frameborder="0" allow="autoplay"></iframe>
 		this.html`
 			<span class="ActiveDot"></span>
-			<video src=${src}></video>
+			<video title=${title} data-src=${src}></video>
 		`
+	}
+
+	loadVideo() {
+		const video = this.querySelector('video')
+		video.src = video.getAttribute('data-src')
 	}
 }


### PR DESCRIPTION
Sometimes a couple (1-3) of the 11 videos fail to load. Doesn't happen always and can't find a way to reliable reproduce. But, this is an attempt to make it more stable.

First try is to load the videos one by one instead of all at once:

1. load one (by setting the `src` attribute manually)
2. wait for the `canplay` event
3. load the next
4. repeat